### PR TITLE
Add libspeexdsp build manifest

### DIFF
--- a/sys-libs/libspeexdsp.py
+++ b/sys-libs/libspeexdsp.py
@@ -1,0 +1,30 @@
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='libspeexdsp',
+    category='sys-libs',
+    description='''
+    Speex is an Open Source/Free Software patent-free audio compression format designed for speech.
+    ''',
+    tags=['sound', 'speech', 'libs', 'gnu'],
+    maintainer='matteo.melis@epiteh.eu',
+    licenses=[stdlib.license.License.BSD],
+    upstream_url='https://www.speex.org/',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '1.2.0',
+            'fetch': [{
+                    'url': 'https://downloads.us.xiph.org/releases/speex/speexdsp-1.2.0.tar.gz',
+                    'sha256': '682042fc6f9bee6294ec453f470dadc26c6ff29b9c9e9ad2ffc1f4312fd64771'
+                },
+            ],
+        },
+    ],
+)
+def build(build):
+    packages = autotools.build()
+    return packages

--- a/sys-libs/libspeexdsp.py
+++ b/sys-libs/libspeexdsp.py
@@ -9,7 +9,7 @@ from stdlib.manifest import manifest
     description='''
     Speex is an Open Source/Free Software patent-free audio compression format designed for speech.
     ''',
-    tags=['sound', 'speech', 'libs', 'gnu'],
+    tags=['sound', 'speech', 'audio', 'media', 'gnu'],
     maintainer='matteo.melis@epiteh.eu',
     licenses=[stdlib.license.License.BSD],
     upstream_url='https://www.speex.org/',


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libspeexdsp.la
[+]      Wrapping sys-libs/libspeexdsp#1.2.0
[+]          name: libspeexdsp
[+]          category: sys-libs
[+]          version: 1.2.0
[+]          description: Speex is an Open Source/Free Software patent-free audio compression format designed for speech.
[+]          tags: sound, speech, libs, gnu
[+]          maintainer: matteo.melis@epiteh.eu
[+]          licenses: bsd
[+]          upstream_url: https://www.speex.org/
[+]          kind: effective
[+]          wrap_date: 2019-11-15T14:59:29Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/lib64/libspeexdsp.so.1 -> libspeexdsp.so.1.5.1
[+]              ./usr/lib64/libspeexdsp.so.1.5.1
[+]              ./usr/lib64/pkgconfig/speexdsp.pc
[+]          (That's 3 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating libspeexdsp-1.2.0.nest
[+]      Wrapping sys-libs/libspeexdsp-dev#1.2.0
[+]          name: libspeexdsp-dev
[+]          category: sys-libs
[+]          version: 1.2.0
[+]          description: Headers and manuals to compile or write a software using the sys-libs/libspeexdsp package.
[+]          tags: sound, speech, libs, gnu
[+]          maintainer: matteo.melis@epiteh.eu
[+]          licenses: bsd
[+]          upstream_url: https://www.speex.org/
[+]          kind: effective
[+]          wrap_date: 2019-11-15T14:59:29Z
[+]          dependencies:
[+]              sys-libs/libspeexdsp#=1.2.0
[+]         
[+]          Files added:
[+]              ./usr/include/speex/speexdsp_types.h
[+]              ./usr/include/speex/speex_echo.h
[+]              ./usr/include/speex/speex_jitter.h
[+]              ./usr/include/speex/speex_preprocess.h
[+]              ./usr/include/speex/speex_resampler.h
[+]              ./usr/include/speex/speexdsp_config_types.h
[+]              ./usr/lib64/libspeexdsp.so -> libspeexdsp.so.1.5.1
[+]              ./usr/lib64/libspeexdsp.a
[+]          (That's 8 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating libspeexdsp-dev-1.2.0.nest
[+]      Wrapping sys-libs/libspeexdsp-doc#1.2.0
[+]          name: libspeexdsp-doc
[+]          category: sys-libs
[+]          version: 1.2.0
[+]          description: Offline documentation of sys-libs/libspeexdsp.
[+]          tags: sound, speech, libs, gnu
[+]          maintainer: matteo.melis@epiteh.eu
[+]          licenses: bsd
[+]          upstream_url: https://www.speex.org/
[+]          kind: effective
[+]          wrap_date: 2019-11-15T14:59:29Z
[+]          dependencies:
[+]         
[+]          Files added:
[+]              ./usr/share/doc/speexdsp/manual.pdf
[+]          (That's 1 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating libspeexdsp-doc-1.2.0.nest
[+]  Done!
```