### PR TITLE
Add dev-libs/json-c build manifest

### DIFF
--- a/dev-libs/json-c.py
+++ b/dev-libs/json-c.py
@@ -1,0 +1,30 @@
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='json-c',
+    category='dev-libs',
+    description='''
+    JSON-C implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects. It aims to conform to RFC 7159.
+    ''',
+    tags=['dev', 'json', 'c', 'libs'],
+    maintainer='matteo.melis@epitech.eu',
+    licenses=[stdlib.license.License.MIT],
+    upstream_url='https://github.com/json-c/json-c',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '0.13.1',
+            'fetch': [{
+                    'url': 'https://github.com/json-c/json-c/archive/json-c-0.13.1-20180305.tar.gz',
+                    'sha256': '5d867baeb7f540abe8f3265ac18ed7a24f91fe3c5f4fd99ac3caba0708511b90',
+                },
+            ],
+        },
+    ],
+)
+def build(build):
+    packages = autotools.build()
+    return packages

--- a/dev-libs/json-c.py
+++ b/dev-libs/json-c.py
@@ -7,7 +7,7 @@ from stdlib.manifest import manifest
     name='json-c',
     category='dev-libs',
     description='''
-    JSON-C implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects. It aims to conform to RFC 7159.
+    A JSON implementation in C.
     ''',
     tags=['json', 'c', 'parser'],
     maintainer='matteo.melis@epitech.eu',

--- a/dev-libs/json-c.py
+++ b/dev-libs/json-c.py
@@ -9,7 +9,7 @@ from stdlib.manifest import manifest
     description='''
     JSON-C implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects. It aims to conform to RFC 7159.
     ''',
-    tags=['dev', 'json', 'c', 'libs'],
+    tags=['json', 'c', 'parser'],
     maintainer='matteo.melis@epitech.eu',
     licenses=[stdlib.license.License.MIT],
     upstream_url='https://github.com/json-c/json-c',


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libjson-c.la
[+]      Wrapping dev-libs/json-c#0.13.1
[+]          name: json-c
[+]          category: dev-libs
[+]          version: 0.13.1
[+]          description: JSON-C implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects. It aims to conform to RFC 7159.
[+]          tags: dev, json, c, libs
[+]          maintainer: matteo.melis@epitech.eu
[+]          licenses: mit
[+]          upstream_url: https://github.com/json-c/json-c
[+]          kind: effective
[+]          wrap_date: 2019-11-15T15:28:02Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/lib64/libjson-c.so.4.0.0
[+]              ./usr/lib64/libjson-c.so.4 -> libjson-c.so.4.0.0
[+]              ./usr/lib64/pkgconfig/json-c.pc
[+]          (That's 3 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating json-c-0.13.1.nest
[+]      Wrapping dev-libs/json-c-dev#0.13.1
[+]          name: json-c-dev
[+]          category: dev-libs
[+]          version: 0.13.1
[+]          description: Headers and manuals to compile or write a software using the dev-libs/json-c package.
[+]          tags: dev, json, c, libs
[+]          maintainer: matteo.melis@epitech.eu
[+]          licenses: mit
[+]          upstream_url: https://github.com/json-c/json-c
[+]          kind: effective
[+]          wrap_date: 2019-11-15T15:28:03Z
[+]          dependencies:
[+]              dev-libs/json-c#=0.13.1
[+]         
[+]          Files added:
[+]              ./usr/include/json-c/debug.h
[+]              ./usr/include/json-c/json_config.h
[+]              ./usr/include/json-c/json_c_version.h
[+]              ./usr/include/json-c/json_object_iterator.h
[+]              ./usr/include/json-c/json.h
[+]              ./usr/include/json-c/json_util.h
[+]              ./usr/include/json-c/json_object.h
[+]              ./usr/include/json-c/linkhash.h
[+]              ./usr/include/json-c/json_tokener.h
[+]              ./usr/include/json-c/bits.h
[+]              ./usr/include/json-c/json_visit.h
[+]              ./usr/include/json-c/json_pointer.h
[+]              ./usr/include/json-c/printbuf.h
[+]              ./usr/include/json-c/arraylist.h
[+]              ./usr/include/json-c/json_inttypes.h
[+]              ./usr/lib64/libjson-c.so -> libjson-c.so.4.0.0
[+]              ./usr/lib64/libjson-c.a
[+]          (That's 17 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating json-c-dev-0.13.1.nest
[+]      Wrapping dev-libs/json-c-doc#0.13.1
[!]      The package is empty -- Skipping
[+]  Done!
```