### PR TITLE
Add the manifest to build the sys-libs/wayland-* packages

### DIFF
--- a/sys-libs/wayland.py
+++ b/sys-libs/wayland.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import stdlib
+from stdlib.template import autotools
+from stdlib.template.configure import configure
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='wayland',
+    category='sys-libs',
+    description='''
+    Wayland is intended as a simpler replacement for X, easier to develop and maintain.
+    ''',
+    tags=['wayland', 'graphics', 'compositor'],
+    maintainer='doom@raven-os.org',
+    licenses=[stdlib.license.License.MIT],
+    upstream_url='https://wayland.freedesktop.org/',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '1.17.0',
+            'fetch': [{
+                'url': 'https://wayland.freedesktop.org/releases/wayland-1.17.0.tar.xz',
+                'sha256': '72aa11b8ac6e22f4777302c9251e8fec7655dc22f9d94ee676c6b276f95f91a4',
+            }],
+        },
+    ],
+    build_dependencies=[
+        'sys-libs/expat-dev',
+        'dev-libs/xml2-dev'
+    ]
+)
+def build(build):
+    packages = autotools.build(
+        configure=lambda: configure(
+            '--disable-documentation'
+        ),
+    )
+
+    packages['sys-libs/wayland-dev'].drain(
+        'usr/share/wayland/'
+    )
+
+    return packages


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libwayland-cursor.la
[!]          usr/lib64/libwayland-server.la
[!]          usr/lib64/libwayland-client.la
[!]          usr/lib64/libwayland-egl.la
[+]      Wrapping sys-libs/wayland#1.17.0
[+]          name: wayland
[+]          category: sys-libs
[+]          version: 1.17.0
[+]          description: Wayland is intended as a simpler replacement for X, easier to develop and maintain.
[+]          tags: wayland, graphics, compositor
[+]          maintainer: doom@raven-os.org
[+]          licenses: mit
[+]          upstream_url: https://wayland.freedesktop.org/
[+]          kind: effective
[+]          wrap_date: 2019-11-18T08:26:30Z
[+]          dependencies:
[+]              sys-libs/expat
[+]              dev-libs/libffi
[+]              dev-libs/xml2
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/share/aclocal/wayland-scanner.m4
[+]              ./usr/lib64/libwayland-client.so.0 -> libwayland-client.so.0.3.0
[+]              ./usr/lib64/libwayland-client.so.0.3.0
[+]              ./usr/lib64/libwayland-server.so.0 -> libwayland-server.so.0.1.0
[+]              ./usr/lib64/libwayland-cursor.so.0 -> libwayland-cursor.so.0.0.0
[+]              ./usr/lib64/libwayland-cursor.so.0.0.0
[+]              ./usr/lib64/libwayland-egl.so.1.0.0
[+]              ./usr/lib64/libwayland-egl.so.1 -> libwayland-egl.so.1.0.0
[+]              ./usr/lib64/libwayland-server.so.0.1.0
[+]              ./usr/lib64/pkgconfig/wayland-scanner.pc
[+]              ./usr/lib64/pkgconfig/wayland-server.pc
[+]              ./usr/lib64/pkgconfig/wayland-client.pc
[+]              ./usr/lib64/pkgconfig/wayland-cursor.pc
[+]              ./usr/lib64/pkgconfig/wayland-egl.pc
[+]              ./usr/lib64/pkgconfig/wayland-egl-backend.pc
[+]              ./usr/bin/wayland-scanner
[+]          (That's 16 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating wayland-1.17.0.nest
[+]      Wrapping sys-libs/wayland-dev#1.17.0
[+]          name: wayland-dev
[+]          category: sys-libs
[+]          version: 1.17.0
[+]          description: Headers and manuals to compile or write a software using the sys-libs/wayland package.
[+]          tags: wayland, graphics, compositor
[+]          maintainer: doom@raven-os.org
[+]          licenses: mit
[+]          upstream_url: https://wayland.freedesktop.org/
[+]          kind: effective
[+]          wrap_date: 2019-11-18T08:26:30Z
[+]          dependencies:
[+]              sys-libs/wayland#=1.17.0
[+]         
[+]          Files added:
[+]              ./usr/share/wayland/wayland-scanner.mk
[+]              ./usr/share/wayland/wayland.xml
[+]              ./usr/share/wayland/wayland.dtd
[+]              ./usr/lib64/libwayland-server.so -> libwayland-server.so.0.1.0
[+]              ./usr/lib64/libwayland-client.a
[+]              ./usr/lib64/libwayland-cursor.so -> libwayland-cursor.so.0.0.0
[+]              ./usr/lib64/libwayland-client.so -> libwayland-client.so.0.3.0
[+]              ./usr/lib64/libwayland-cursor.a
[+]              ./usr/lib64/libwayland-egl.a
[+]              ./usr/lib64/libwayland-egl.so -> libwayland-egl.so.1.0.0
[+]              ./usr/lib64/libwayland-server.a
[+]              ./usr/include/wayland-version.h
[+]              ./usr/include/wayland-cursor.h
[+]              ./usr/include/wayland-server-protocol.h
[+]              ./usr/include/wayland-client-protocol.h
[+]              ./usr/include/wayland-egl.h
[+]              ./usr/include/wayland-server.h
[+]              ./usr/include/wayland-server-core.h
[+]              ./usr/include/wayland-egl-core.h
[+]              ./usr/include/wayland-util.h
[+]              ./usr/include/wayland-client.h
[+]              ./usr/include/wayland-client-core.h
[+]              ./usr/include/wayland-egl-backend.h
[+]          (That's 23 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating wayland-dev-1.17.0.nest
[+]      Wrapping sys-libs/wayland-doc#1.17.0
[!]      The package is empty -- Skipping
[+]  Done!
```