### PR TITLE
Add the manifest to build dev-libs/mtdev*.

### DIFF
--- a/dev-libs/mtdev.py
+++ b/dev-libs/mtdev.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='mtdev',
+    category='dev-libs',
+    description='''
+    A Multitouch Protocol Translation Library which transforms all variants of kernel MT events to the slotted type B protocol
+    ''',
+    tags=['input', 'multitouch', 'protocol', 'translater', 'mt'],
+    maintainer='grange_c@raven-os.org',
+    licenses=[stdlib.license.License.MIT, stdlib.license.License.CUSTOM],
+    upstream_url='https://bitmath.org/code/mtdev/',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '1.1.5',
+            'fetch': [{
+                    'url': 'https://bitmath.org/code/mtdev/mtdev-1.1.5.tar.gz',
+                    'sha256': 'a662924dd09cf538c8df66514da345e40c3cbfa880cc7262bc3b55ee46d0c1f4',
+                },
+            ],
+        },
+    ],
+)
+def build(build):
+    return autotools.build()


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libmtdev.la
[+]      Wrapping dev-libs/mtdev#1.1.5
[+]          name: mtdev
[+]          category: dev-libs
[+]          version: 1.1.5
[+]          description: A Multitouch Protocol Translation Library which transforms all variants of kernel MT events to the slotted type B protocol
[+]          tags: input, multitouch, protocol, translater, mt
[+]          maintainer: grange_c@raven-os.org
[+]          licenses: mit, custom
[+]          upstream_url: https://bitmath.org/code/mtdev/
[+]          kind: effective
[+]          wrap_date: 2019-11-18T15:51:01Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/lib64/libmtdev.so.1 -> libmtdev.so.1.0.0
[+]              ./usr/lib64/libmtdev.so.1.0.0
[+]              ./usr/lib64/pkgconfig/mtdev.pc
[+]              ./usr/bin/mtdev-test
[+]          (That's 4 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating mtdev-1.1.5.nest
[+]      Wrapping dev-libs/mtdev-dev#1.1.5
[+]          name: mtdev-dev
[+]          category: dev-libs
[+]          version: 1.1.5
[+]          description: Headers and manuals to compile or write a software using the dev-libs/mtdev package.
[+]          tags: input, multitouch, protocol, translater, mt
[+]          maintainer: grange_c@raven-os.org
[+]          licenses: mit, custom
[+]          upstream_url: https://bitmath.org/code/mtdev/
[+]          kind: effective
[+]          wrap_date: 2019-11-18T15:51:01Z
[+]          dependencies:
[+]              dev-libs/mtdev#=1.1.5
[+]         
[+]          Files added:
[+]              ./usr/lib64/libmtdev.so -> libmtdev.so.1.0.0
[+]              ./usr/lib64/libmtdev.a
[+]              ./usr/include/mtdev-plumbing.h
[+]              ./usr/include/mtdev.h
[+]              ./usr/include/mtdev-mapping.h
[+]          (That's 5 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating mtdev-dev-1.1.5.nest
[+]      Wrapping dev-libs/mtdev-doc#1.1.5
[!]      The package is empty -- Skipping
[+]  Done!
```