### PR TITLE
Add the manifest to build dev-libs/evdev*.

### DIFF
--- a/dev-libs/evdev.py
+++ b/dev-libs/evdev.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='evdev',
+    category='dev-libs',
+    description='''
+    A handler library for evdev events and devices.
+    ''',
+    tags=['evdev', 'device'],
+    maintainer='grange_c@raven-os.org',
+    licenses=[stdlib.license.License.CUSTOM],
+    upstream_url='https://www.freedesktop.org/wiki/Software/libevdev/',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '1.8.0',
+            'fetch': [{
+                    'url': 'https://www.freedesktop.org/software/libevdev/libevdev-1.8.0.tar.xz',
+                    'sha256': '20d3cae4efd277f485abdf8f2a7c46588e539998b5a08c2c4d368218379d4211',
+                },
+            ],
+        },
+    ],
+)
+def build(build):
+    return autotools.build()

--- a/kernel/linux/config-5.2.17
+++ b/kernel/linux/config-5.2.17
@@ -4,7 +4,7 @@
 #
 
 #
-# Compiler: gcc (Gentoo 8.3.0-r1 p1.1) 8.3.0
+# Compiler: gcc (Gentoo 8.3.0-r2 p2) 8.3.0
 #
 CONFIG_CC_IS_GCC=y
 CONFIG_GCC_VERSION=80300
@@ -2206,7 +2206,7 @@ CONFIG_INPUT_MISC=y
 # CONFIG_INPUT_POWERMATE is not set
 # CONFIG_INPUT_YEALINK is not set
 # CONFIG_INPUT_CM109 is not set
-# CONFIG_INPUT_UINPUT is not set
+CONFIG_INPUT_UINPUT=m
 # CONFIG_INPUT_PCF8574 is not set
 # CONFIG_INPUT_ADXL34X is not set
 # CONFIG_INPUT_IMS_PCU is not set


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libevdev.la
[+]      Wrapping dev-libs/evdev#1.8.0
[+]          name: evdev
[+]          category: dev-libs
[+]          version: 1.8.0
[+]          description: A handler library for evdev events and devices.
[+]          tags: evdev, device
[+]          maintainer: grange_c@raven-os.org
[+]          licenses: custom
[+]          upstream_url: https://www.freedesktop.org/wiki/Software/libevdev/
[+]          kind: effective
[+]          wrap_date: 2019-11-18T16:06:34Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/lib64/libevdev.so.2 -> libevdev.so.2.3.0
[+]              ./usr/lib64/libevdev.so.2.3.0
[+]              ./usr/lib64/pkgconfig/libevdev.pc
[+]              ./usr/bin/touchpad-edge-detector
[+]              ./usr/bin/mouse-dpi-tool
[+]              ./usr/bin/libevdev-tweak-device
[+]          (That's 6 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating evdev-1.8.0.nest
[+]      Wrapping dev-libs/evdev-dev#1.8.0
[+]          name: evdev-dev
[+]          category: dev-libs
[+]          version: 1.8.0
[+]          description: Headers and manuals to compile or write a software using the dev-libs/evdev package.
[+]          tags: evdev, device
[+]          maintainer: grange_c@raven-os.org
[+]          licenses: custom
[+]          upstream_url: https://www.freedesktop.org/wiki/Software/libevdev/
[+]          kind: effective
[+]          wrap_date: 2019-11-18T16:06:34Z
[+]          dependencies:
[+]              dev-libs/evdev#=1.8.0
[+]         
[+]          Files added:
[+]              ./usr/share/man/man3/libevdev.3
[+]              ./usr/lib64/libevdev.a
[+]              ./usr/lib64/libevdev.so -> libevdev.so.2.3.0
[+]              ./usr/include/libevdev-1.0/libevdev/libevdev.h
[+]              ./usr/include/libevdev-1.0/libevdev/libevdev-uinput.h
[+]          (That's 5 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating evdev-dev-1.8.0.nest
[+]      Wrapping dev-libs/evdev-doc#1.8.0
[!]      The package is empty -- Skipping
[+]  Done!
```