### PR TITLE
Add the manifest to build the dev-libs/libpng-* packages

### DIFF
--- a/dev-libs/libpng.py
+++ b/dev-libs/libpng.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='libpng',
+    category='dev-libs',
+    description='''
+    The libpng package contains libraries used for reading and writing PNG files.
+    ''',
+    tags=['png', 'image'],
+    maintainer='doom@raven-os.org',
+    licenses=[stdlib.license.License.CUSTOM],
+    upstream_url='http://www.libpng.org/pub/png/libpng.html',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '1.6.37',
+            'fetch': [{
+                'url': 'https://downloads.sourceforge.net/libpng/libpng-1.6.37.tar.xz',
+                'sha256': '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca',
+            }],
+        },
+    ],
+    build_dependencies=[
+        'sys-libs/zlib-dev'
+    ]
+)
+def build(build):
+    return autotools.build()


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libpng.la
[!]          usr/lib64/libpng16.la
[+]      Wrapping dev-libs/libpng#1.6.37
[+]          name: libpng
[+]          category: dev-libs
[+]          version: 1.6.37
[+]          description: The libpng package contains libraries used for reading and writing PNG files.
[+]          tags: png, image
[+]          maintainer: doom@raven-os.org
[+]          licenses: gpl_v3
[+]          upstream_url: http://www.libpng.org/pub/png/libpng.html
[+]          kind: effective
[+]          wrap_date: 2019-11-20T13:32:27Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]              sys-libs/zlib
[+]         
[+]          Files added:
[+]              ./usr/share/man/man5/png.5
[+]              ./usr/lib64/libpng16.so.16.37.0
[+]              ./usr/lib64/libpng16.so.16 -> libpng16.so.16.37.0
[+]              ./usr/lib64/pkgconfig/libpng16.pc
[+]              ./usr/lib64/pkgconfig/libpng.pc -> libpng16.pc
[+]              ./usr/bin/pngfix
[+]              ./usr/bin/libpng-config -> libpng16-config
[+]              ./usr/bin/libpng16-config
[+]              ./usr/bin/png-fix-itxt
[+]          (That's 9 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating libpng-1.6.37.nest
[+]      Wrapping dev-libs/libpng-dev#1.6.37
[+]          name: libpng-dev
[+]          category: dev-libs
[+]          version: 1.6.37
[+]          description: Headers and manuals to compile or write a software using the dev-libs/libpng package.
[+]          tags: png, image
[+]          maintainer: doom@raven-os.org
[+]          licenses: gpl_v3
[+]          upstream_url: http://www.libpng.org/pub/png/libpng.html
[+]          kind: effective
[+]          wrap_date: 2019-11-20T13:32:27Z
[+]          dependencies:
[+]              dev-libs/libpng#=1.6.37
[+]         
[+]          Files added:
[+]              ./usr/share/man/man3/libpngpf.3
[+]              ./usr/share/man/man3/libpng.3
[+]              ./usr/lib64/libpng.a -> libpng16.a
[+]              ./usr/lib64/libpng16.a
[+]              ./usr/lib64/libpng.so -> libpng16.so
[+]              ./usr/lib64/libpng16.so -> libpng16.so.16.37.0
[+]              ./usr/include/png.h -> libpng16/png.h
[+]              ./usr/include/pnglibconf.h -> libpng16/pnglibconf.h
[+]              ./usr/include/pngconf.h -> libpng16/pngconf.h
[+]              ./usr/include/libpng16/png.h
[+]              ./usr/include/libpng16/pnglibconf.h
[+]              ./usr/include/libpng16/pngconf.h
[+]          (That's 12 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating libpng-dev-1.6.37.nest
[+]      Wrapping dev-libs/libpng-doc#1.6.37
[!]      The package is empty -- Skipping
[+]  Done!

```