### PR TITLE
Add dev-libs/c-ares build manifest

### DIFF
--- a/dev-libs/c-ares.py
+++ b/dev-libs/c-ares.py
@@ -1,0 +1,29 @@
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='c-ares',
+    category='dev-libs',
+    description='''
+    A C library for asynchronous DNS requests.
+    ''',
+    tags=['dns', 'c', 'asynchronous'],
+    maintainer='matteo.melis@epitech.eu',
+    licenses=[stdlib.license.License.MIT],
+    upstream_url='https://github.com/c-ares/c-ares/',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '1.15.0',
+            'fetch': [{
+                    'url': 'https://c-ares.haxx.se/download/c-ares-1.15.0.tar.gz',
+                    'sha256': '6cdb97871f2930530c97deb7cf5c8fa4be5a0b02c7cea6e7c7667672a39d6852',
+                },
+            ],
+        },
+    ],
+)
+def build(build):
+    return autotools.build()


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libcares.la
[+]      Wrapping dev-libs/c-ares#1.15.0
[+]          name: c-ares
[+]          category: dev-libs
[+]          version: 1.15.0
[+]          description: A C library for asynchronous DNS requests.
[+]          tags: dns, c, asynchronous
[+]          maintainer: matteo.melis@epitech.eu
[+]          licenses: mit
[+]          upstream_url: https://github.com/c-ares/c-ares/
[+]          kind: effective
[+]          wrap_date: 2019-11-21T14:02:50Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/lib64/libcares.so.2 -> libcares.so.2.3.0
[+]              ./usr/lib64/libcares.so.2.3.0
[+]              ./usr/lib64/pkgconfig/libcares.pc
[+]          (That's 3 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating c-ares-1.15.0.nest
[+]      Wrapping dev-libs/c-ares-dev#1.15.0
[+]          name: c-ares-dev
[+]          category: dev-libs
[+]          version: 1.15.0
[+]          description: Headers and manuals to compile or write a software using the dev-libs/c-ares package.
[+]          tags: dns, c, asynchronous
[+]          maintainer: matteo.melis@epitech.eu
[+]          licenses: mit
[+]          upstream_url: https://github.com/c-ares/c-ares/
[+]          kind: effective
[+]          wrap_date: 2019-11-21T14:02:50Z
[+]          dependencies:
[+]              dev-libs/c-ares#=1.15.0
[+]         
[+]          Files added:
[+]              ./usr/include/ares_build.h
[+]              ./usr/include/ares_dns.h
[+]              ./usr/include/ares_rules.h
[+]              ./usr/include/ares.h
[+]              ./usr/include/ares_version.h
[+]              ./usr/lib64/libcares.so -> libcares.so.2.3.0
[+]              ./usr/lib64/libcares.a
[+]              ./usr/share/man/man3/ares_cancel.3
[+]              ./usr/share/man/man3/ares_set_local_ip6.3
[+]              ./usr/share/man/man3/ares_parse_mx_reply.3
[+]              ./usr/share/man/man3/ares_init.3
[+]              ./usr/share/man/man3/ares_set_socket_configure_callback.3
[+]              ./usr/share/man/man3/ares_set_socket_functions.3
[+]              ./usr/share/man/man3/ares_parse_soa_reply.3
[+]              ./usr/share/man/man3/ares_parse_txt_reply.3
[+]              ./usr/share/man/man3/ares_parse_srv_reply.3
[+]              ./usr/share/man/man3/ares_library_init_android.3
[+]              ./usr/share/man/man3/ares_mkquery.3
[+]              ./usr/share/man/man3/ares_create_query.3
[+]              ./usr/share/man/man3/ares_version.3
[+]              ./usr/share/man/man3/ares_parse_ptr_reply.3
[+]              ./usr/share/man/man3/ares_set_sortlist.3
[+]              ./usr/share/man/man3/ares_parse_ns_reply.3
[+]              ./usr/share/man/man3/ares_free_hostent.3
[+]              ./usr/share/man/man3/ares_library_init.3
[+]              ./usr/share/man/man3/ares_gethostbyaddr.3
[+]              ./usr/share/man/man3/ares_search.3
[+]              ./usr/share/man/man3/ares_set_servers.3
[+]              ./usr/share/man/man3/ares_init_options.3
[+]              ./usr/share/man/man3/ares_strerror.3
[+]              ./usr/share/man/man3/ares_send.3
[+]              ./usr/share/man/man3/ares_save_options.3
[+]              ./usr/share/man/man3/ares_get_servers_ports.3
[+]              ./usr/share/man/man3/ares_expand_string.3
[+]              ./usr/share/man/man3/ares_set_servers_ports.3
[+]              ./usr/share/man/man3/ares_set_servers_ports_csv.3
[+]              ./usr/share/man/man3/ares_expand_name.3
[+]              ./usr/share/man/man3/ares_free_data.3
[+]              ./usr/share/man/man3/ares_set_local_dev.3
[+]              ./usr/share/man/man3/ares_query.3
[+]              ./usr/share/man/man3/ares_getnameinfo.3
[+]              ./usr/share/man/man3/ares_set_socket_callback.3
[+]              ./usr/share/man/man3/ares_process.3
[+]              ./usr/share/man/man3/ares_inet_ntop.3
[+]              ./usr/share/man/man3/ares_destroy.3
[+]              ./usr/share/man/man3/ares_library_initialized.3
[+]              ./usr/share/man/man3/ares_destroy_options.3
[+]              ./usr/share/man/man3/ares_gethostbyname_file.3
[+]              ./usr/share/man/man3/ares_set_local_ip4.3
[+]              ./usr/share/man/man3/ares_parse_naptr_reply.3
[+]              ./usr/share/man/man3/ares_getsock.3
[+]              ./usr/share/man/man3/ares_library_cleanup.3
[+]              ./usr/share/man/man3/ares_get_servers.3
[+]              ./usr/share/man/man3/ares_parse_a_reply.3
[+]              ./usr/share/man/man3/ares_set_servers_csv.3
[+]              ./usr/share/man/man3/ares_inet_pton.3
[+]              ./usr/share/man/man3/ares_free_string.3
[+]              ./usr/share/man/man3/ares_dup.3
[+]              ./usr/share/man/man3/ares_gethostbyname.3
[+]              ./usr/share/man/man3/ares_fds.3
[+]              ./usr/share/man/man3/ares_parse_aaaa_reply.3
[+]              ./usr/share/man/man3/ares_timeout.3
[+]          (That's 62 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating c-ares-dev-1.15.0.nest
[+]      Wrapping dev-libs/c-ares-doc#1.15.0
[!]      The package is empty -- Skipping
[+]  Done!
```