### PR TITLE
Add the manifest to build the sys-apps/lzip-* packages

### DIFF
--- a/sys-apps/lzip.py
+++ b/sys-apps/lzip.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='lzip',
+    category='sys-apps',
+    description='''
+    Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2.
+    ''',
+    tags=['compression', 'decompression'],
+    maintainer='doom@raven-os.org',
+    licenses=[stdlib.license.License.GPL_V3],
+    upstream_url='https://www.nongnu.org/lzip/',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '1.21.0',
+            'fetch': [
+                {
+                    'url': 'http://download.savannah.gnu.org/releases/lzip/lzip-1.21.tar.gz',
+                    'sha256': 'e48b5039d3164d670791f9c5dbaa832bf2df080cb1fbb4f33aa7b3300b670d8b',
+                }
+            ],
+        },
+    ]
+)
+def build(build):
+    return autotools.build()


### PR DESCRIPTION
```
[+]      Wrapping sys-apps/lzip#1.21.0
[+]          name: lzip
[+]          category: sys-apps
[+]          version: 1.21.0
[+]          description: Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2.
[+]          tags: compression, decompression
[+]          maintainer: doom@raven-os.org
[+]          licenses: gpl_v3
[+]          upstream_url: https://www.nongnu.org/lzip/
[+]          kind: effective
[+]          wrap_date: 2019-11-22T17:23:57Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]              sys-libs/gcc-libs
[+]         
[+]          Files added:
[+]              ./usr/share/man/man1/lzip.1
[+]              ./usr/bin/lzip
[+]          (That's 2 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating lzip-1.21.0.nest
[+]      Wrapping sys-apps/lzip-dev#1.21.0
[!]      The package is empty -- Skipping
[+]      Wrapping sys-apps/lzip-doc#1.21.0
[+]          name: lzip-doc
[+]          category: sys-apps
[+]          version: 1.21.0
[+]          description: Offline documentation of sys-apps/lzip.
[+]          tags: compression, decompression
[+]          maintainer: doom@raven-os.org
[+]          licenses: gpl_v3
[+]          upstream_url: https://www.nongnu.org/lzip/
[+]          kind: effective
[+]          wrap_date: 2019-11-22T17:23:57Z
[+]          dependencies:
[+]         
[+]          Files added:
[+]              ./usr/share/info/lzip.info
[+]          (That's 1 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating lzip-doc-1.21.0.nest
[+]  Done!
```