### PR TITLE
Add the sys-apps/dbus-glib build manifest

### DIFF
--- a/sys-apps/dbus-glib.py
+++ b/sys-apps/dbus-glib.py
@@ -4,6 +4,7 @@
 import stdlib
 from stdlib.template import autotools
 from stdlib.manifest import manifest
+from stdlib.template.configure import configure
 
 
 @manifest(
@@ -37,5 +38,6 @@ def build(build):
     packages = autotools.build()
 
     packages['dev-libs/dbus-glib'].drain('usr/lib64/dbus-bash-completion-helper')
+    packages['dev-libs/dbus-glib-doc'].drain('usr/share/gtk-doc/')
 
     return packages

--- a/sys-apps/dbus-glib.py
+++ b/sys-apps/dbus-glib.py
@@ -4,7 +4,6 @@
 import stdlib
 from stdlib.template import autotools
 from stdlib.manifest import manifest
-from stdlib.template.configure import configure
 
 
 @manifest(

--- a/sys-apps/dbus-glib.py
+++ b/sys-apps/dbus-glib.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='dbus-glib',
+    category='dev-libs',
+    description='''
+    GLib interfaces to the D-Bus API.
+    ''',
+    tags=['glib', 'dbus', 'interface'],
+    maintainer='dorian.trubelle@epitech.eu',
+    licenses=[stdlib.license.License.GPL],
+    upstream_url='https://www.freedesktop.org/wiki/Software/DBusBindings',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '0.110.0',
+            'fetch': [{
+                    'url': 'https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.110.tar.gz',
+                    'sha256': '7ce4760cf66c69148f6bd6c92feaabb8812dee30846b24cd0f7395c436d7e825',
+                },
+            ],
+        },
+    ],
+    build_dependencies=[
+        'sys-apps/dbus-dev',
+        'dev-libs/glib-dev',
+        'sys-libs/expat-dev'
+    ]
+)
+def build(build):
+    packages = autotools.build()
+
+    packages['dev-libs/dbus-glib'].drain('usr/lib64/dbus-bash-completion-helper')
+
+    return packages


### PR DESCRIPTION
```
[!]      Some built files haven't been moved to any package:
[!]          usr/lib64/libdbus-glib-1.la
[!]          usr/share/gtk-doc/html/dbus-glib/ch01.html
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-DBus-GObject-related-functions.html
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-Specializable-GType-System.html
[!]          usr/share/gtk-doc/html/dbus-glib/left-insensitive.png
[!]          usr/share/gtk-doc/html/dbus-glib/right-insensitive.png
[!]          usr/share/gtk-doc/html/dbus-glib/right.png
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-DBusGProxy.html
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-DBusGConnection.html
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-DBusGMethod.html
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-DBusGMessage.html
[!]          usr/share/gtk-doc/html/dbus-glib/home.png
[!]          usr/share/gtk-doc/html/dbus-glib/api-index-full.html
[!]          usr/share/gtk-doc/html/dbus-glib/style.css
[!]          usr/share/gtk-doc/html/dbus-glib/index.html
[!]          usr/share/gtk-doc/html/dbus-glib/ch03.html
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-binding-tool.html
[!]          usr/share/gtk-doc/html/dbus-glib/left.png
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-DBus-GLib-low-level.html
[!]          usr/share/gtk-doc/html/dbus-glib/up-insensitive.png
[!]          usr/share/gtk-doc/html/dbus-glib/up.png
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib-DBusGError.html
[!]          usr/share/gtk-doc/html/dbus-glib/dbus-glib.devhelp2
[!]          usr/share/gtk-doc/html/dbus-glib/ch02.html
[+]      Wrapping dev-libs/dbus-glib#0.110.0
[+]          name: dbus-glib
[+]          category: dev-libs
[+]          version: 0.110.0
[+]          description: GLib interfaces to the D-Bus API.
[+]          tags: glib, dbus, interface
[+]          maintainer: dorian.trubelle@epitech.eu
[+]          licenses: gpl
[+]          upstream_url: https://www.freedesktop.org/wiki/Software/DBusBindings
[+]          kind: effective
[+]          wrap_date: 2019-11-30T15:06:07Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]              dev-libs/glib
[+]              sys-apps/dbus
[+]              sys-libs/expat
[+]         
[+]          Files added:
[+]              ./usr/lib64/libdbus-glib-1.so.2 -> libdbus-glib-1.so.2.3.4
[+]              ./usr/lib64/libdbus-glib-1.so.2.3.4
[+]              ./usr/lib64/dbus-bash-completion-helper
[+]              ./usr/lib64/pkgconfig/dbus-glib-1.pc
[+]              ./usr/share/man/man1/dbus-binding-tool.1
[+]              ./usr/bin/dbus-binding-tool
[+]              ./etc/bash_completion.d/dbus-bash-completion.sh
[+]          (That's 7 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating dbus-glib-0.110.0.nest
[+]      Wrapping dev-libs/dbus-glib-dev#0.110.0
[+]          name: dbus-glib-dev
[+]          category: dev-libs
[+]          version: 0.110.0
[+]          description: Headers and manuals to compile or write a software using the dev-libs/dbus-glib package.
[+]          tags: glib, dbus, interface
[+]          maintainer: dorian.trubelle@epitech.eu
[+]          licenses: gpl
[+]          upstream_url: https://www.freedesktop.org/wiki/Software/DBusBindings
[+]          kind: effective
[+]          wrap_date: 2019-11-30T15:06:07Z
[+]          dependencies:
[+]              dev-libs/dbus-glib#=0.110.0
[+]         
[+]          Files added:
[+]              ./usr/include/dbus-1.0/dbus/dbus-glib.h
[+]              ./usr/include/dbus-1.0/dbus/dbus-gvalue-parse-variant.h
[+]              ./usr/include/dbus-1.0/dbus/dbus-glib-lowlevel.h
[+]              ./usr/include/dbus-1.0/dbus/dbus-glib-bindings.h
[+]              ./usr/include/dbus-1.0/dbus/dbus-gtype-specialized.h
[+]              ./usr/lib64/libdbus-glib-1.so -> libdbus-glib-1.so.2.3.4
[+]              ./usr/lib64/libdbus-glib-1.a
[+]          (That's 7 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating dbus-glib-dev-0.110.0.nest
[+]      Wrapping dev-libs/dbus-glib-doc#0.110.0
[!]      The package is empty -- Skipping
[+]  Done!
```