### PR TITLE
Add the dev-apps/js build manifest

### DIFF
--- a/dev-apps/js.py
+++ b/dev-apps/js.py
@@ -38,21 +38,17 @@ from stdlib.manifest import manifest
     ]
 )
 def build(build):
+    os.environ['SHELL'] = '/bin/bash'
+
     packages = autotools.build(
-        # export SHELL is required because we're building the package in the chroot environment
-        configure=lambda: stdlib.cmd("SHELL=/bin/bash && export SHELL &&\
-            mkdir mozjs-build &&                                        \
-            cd mozjs-build &&                                           \
-            ../js/src/configure --prefix=/usr                           \
+        build_folder='mozjs-build',
+        configure=lambda: stdlib.cmd(f"../js/src/configure --prefix=/usr\
             --with-intl-api                                             \
             --with-system-zlib                                          \
             --with-system-icu                                           \
             --disable-jemalloc                                          \
             --enable-readline                                           \
         "),
-        compile=lambda: stdlib.cmd("SHELL=/bin/bash && export SHELL &&\
-            cd mozjs-build && make"),
-        install=lambda: stdlib.cmd("cd mozjs-build && make install")
     )
 
     packages['dev-apps/js-dev'].drain('usr/lib/libjs_static.ajs')

--- a/dev-apps/js.py
+++ b/dev-apps/js.py
@@ -12,9 +12,9 @@ from stdlib.manifest import manifest
     name='js',
     category='dev-apps',
     description='''
-    JavaScript interpreter and libraries - Version 60.
+    JavaScript interpreter and libraries.
     ''',
-    tags=['JavaScript', 'Mozilla', 'JS'],
+    tags=['javascript', 'mozilla', 'js', 'interpreter'],
     maintainer='dorian.trubelle@epitech.eu',
     licenses=[stdlib.license.License.MOZILLA],
     upstream_url='https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey',

--- a/dev-apps/js.py
+++ b/dev-apps/js.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import os
+import stdlib
+from stdlib.template import autotools
+from stdlib.template.configure import configure
+from stdlib.manifest import manifest
+
+
+@manifest(
+    name='js',
+    category='dev-apps',
+    description='''
+    JavaScript interpreter and libraries - Version 60.
+    ''',
+    tags=['JavaScript', 'Mozilla', 'JS'],
+    maintainer='dorian.trubelle@epitech.eu',
+    licenses=[stdlib.license.License.MOZILLA],
+    upstream_url='https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '60.8.0',
+            'fetch': [{
+                'url': 'http://ftp.gnome.org/pub/gnome/teams/releng/tarballs-needing-help/mozjs/mozjs-60.8.0.tar.bz2',
+                'sha256': '697331336c3d65b80ded9ca87b4a8ceb804e5342b476eaa133ac638102a9dc5d',
+            },
+            ],
+        },
+    ],
+    build_dependencies=[
+        'dev-libs/icu-dev',
+        'sys-apps/which',
+        'dev-lang/python2',
+        'sys-libs/readline-dev',
+        'autoconf2-13'
+    ]
+)
+def build(build):
+    packages = autotools.build(
+        # export SHELL is required because we're building the package in the chroot environment
+        configure=lambda: stdlib.cmd("SHELL=/bin/bash && export SHELL &&\
+            mkdir mozjs-build &&                                        \
+            cd mozjs-build &&                                           \
+            ../js/src/configure --prefix=/usr                           \
+            --with-intl-api                                             \
+            --with-system-zlib                                          \
+            --with-system-icu                                           \
+            --disable-jemalloc                                          \
+            --enable-readline                                           \
+        "),
+        compile=lambda: stdlib.cmd("SHELL=/bin/bash && export SHELL &&\
+            cd mozjs-build && make"),
+        install=lambda: stdlib.cmd("cd mozjs-build && make install")
+    )
+
+    packages['dev-apps/js-dev'].drain('usr/lib/libjs_static.ajs')
+
+    return packages

--- a/dev-apps/js.py
+++ b/dev-apps/js.py
@@ -34,7 +34,7 @@ from stdlib.manifest import manifest
         'sys-apps/which',
         'dev-lang/python2',
         'sys-libs/readline-dev',
-        'autoconf2-13'
+        'dev-apps/autoconf2-13'
     ]
 )
 def build(build):


### PR DESCRIPTION
Full output below. All files belong to one of the packages (this manifest requires autoconf2-13, you should probably merge that other PR before this one)
```
[+]      Wrapping dev-apps/js#60.8.0
[+]          name: js
[+]          category: dev-apps
[+]          version: 60.8.0
[+]          description: JavaScript interpreter and libraries - Version 60.
[+]          tags: JavaScript, Mozilla, JS
[+]          maintainer: dorian.trubelle@epitech.eu
[+]          licenses: mozilla
[+]          upstream_url: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
[+]          kind: effective
[+]          wrap_date: 2019-12-10T23:27:15Z
[+]          dependencies:
[+]              sys-libs/gcc-libs
[+]              sys-libs/readline
[+]              dev-libs/icu
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/lib/pkgconfig/mozjs-60.pc
[+]              ./usr/bin/js60
[+]              ./usr/bin/js60-config
[+]          (That's 3 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating js-60.8.0.nest
[+]      Wrapping dev-apps/js-dev#60.8.0
[+]          name: js-dev
[+]          category: dev-apps
[+]          version: 60.8.0
[+]          description: Headers and manuals to compile or write a software using the dev-apps/js package.
[+]          tags: JavaScript, Mozilla, JS
[+]          maintainer: dorian.trubelle@epitech.eu
[+]          licenses: mozilla
[+]          upstream_url: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
[+]          kind: effective
[+]          wrap_date: 2019-12-10T23:27:17Z
[+]          dependencies:
[+]              sys-libs/gcc-libs
[+]              dev-apps/js#=60.8.0
[+]              dev-libs/icu
[+]              sys-libs/glibc
[+]         
[+]          Files added:
[+]              ./usr/include/mozjs-60/malloc_decls.h
[+]              ./usr/include/mozjs-60/mozmemory.h
[+]              ./usr/include/mozjs-60/zlib.h
[+]              ./usr/include/mozjs-60/js.msg
[+]              ./usr/include/mozjs-60/jsperf.h
[+]              ./usr/include/mozjs-60/mozmemory_wrap.h
[+]              ./usr/include/mozjs-60/mozjemalloc_types.h
[+]              ./usr/include/mozjs-60/js-config.h
[+]              ./usr/include/mozjs-60/jsfriendapi.h
[+]              ./usr/include/mozjs-60/mozzconf.h
[+]              ./usr/include/mozjs-60/zconf.h
[+]              ./usr/include/mozjs-60/fdlibm.h
[+]              ./usr/include/mozjs-60/jspubtd.h
[+]              ./usr/include/mozjs-60/jsapi.h
[+]              ./usr/include/mozjs-60/jstypes.h
[+]              ./usr/include/mozjs-60/double-conversion/utils.h
[+]              ./usr/include/mozjs-60/double-conversion/double-conversion.h
[+]              ./usr/include/mozjs-60/mozilla/BufferList.h
[+]              ./usr/include/mozjs-60/mozilla/TypedEnumBits.h
[+]              ./usr/include/mozjs-60/mozilla/Maybe.h
[+]              ./usr/include/mozjs-60/mozilla/Atomics.h
[+]              ./usr/include/mozjs-60/mozilla/Result.h
[+]              ./usr/include/mozjs-60/mozilla/Alignment.h
[+]              ./usr/include/mozjs-60/mozilla/Path.h
[+]              ./usr/include/mozjs-60/mozilla/AlreadyAddRefed.h
[+]              ./usr/include/mozjs-60/mozilla/SplayTree.h
[+]              ./usr/include/mozjs-60/mozilla/StackWalk.h
[+]              ./usr/include/mozjs-60/mozilla/StaticAnalysisFunctions.h
[+]              ./usr/include/mozjs-60/mozilla/Pair.h
[+]              ./usr/include/mozjs-60/mozilla/mozalloc_oom.h
[+]              ./usr/include/mozjs-60/mozilla/LinuxSignal.h
[+]              ./usr/include/mozjs-60/mozilla/MacroForEach.h
[+]              ./usr/include/mozjs-60/mozilla/EnumTypeTraits.h
[+]              ./usr/include/mozjs-60/mozilla/ReentrancyGuard.h
[+]              ./usr/include/mozjs-60/mozilla/SHA1.h
[+]              ./usr/include/mozjs-60/mozilla/Poison.h
[+]              ./usr/include/mozjs-60/mozilla/Span.h
[+]              ./usr/include/mozjs-60/mozilla/BloomFilter.h
[+]              ./usr/include/mozjs-60/mozilla/ChaosMode.h
[+]              ./usr/include/mozjs-60/mozilla/WrappingOperations.h
[+]              ./usr/include/mozjs-60/mozilla/Sprintf.h
[+]              ./usr/include/mozjs-60/mozilla/DefineEnum.h
[+]              ./usr/include/mozjs-60/mozilla/LinkedList.h
[+]              ./usr/include/mozjs-60/mozilla/TextUtils.h
[+]              ./usr/include/mozjs-60/mozilla/fallible.h
[+]              ./usr/include/mozjs-60/mozilla/MacroArgs.h
[+]              ./usr/include/mozjs-60/mozilla/Attributes.h
[+]              ./usr/include/mozjs-60/mozilla/HashFunctions.h
[+]              ./usr/include/mozjs-60/mozilla/EnumeratedRange.h
[+]              ./usr/include/mozjs-60/mozilla/FStream.h
[+]              ./usr/include/mozjs-60/mozilla/EndianUtils.h
[+]              ./usr/include/mozjs-60/mozilla/Char16.h
[+]              ./usr/include/mozjs-60/mozilla/RefCounted.h
[+]              ./usr/include/mozjs-60/mozilla/TemplateLib.h
[+]              ./usr/include/mozjs-60/mozilla/ArrayUtils.h
[+]              ./usr/include/mozjs-60/mozilla/Casting.h
[+]              ./usr/include/mozjs-60/mozilla/BinarySearch.h
[+]              ./usr/include/mozjs-60/mozilla/MemoryChecking.h
[+]              ./usr/include/mozjs-60/mozilla/RollingMean.h
[+]              ./usr/include/mozjs-60/mozilla/Move.h
[+]              ./usr/include/mozjs-60/mozilla/DoublyLinkedList.h
[+]              ./usr/include/mozjs-60/mozilla/Assertions.h
[+]              ./usr/include/mozjs-60/mozilla/Unused.h
[+]              ./usr/include/mozjs-60/mozilla/ToString.h
[+]              ./usr/include/mozjs-60/mozilla/ScopeExit.h
[+]              ./usr/include/mozjs-60/mozilla/Variant.h
[+]              ./usr/include/mozjs-60/mozilla/PlatformConditionVariable.h
[+]              ./usr/include/mozjs-60/mozilla/NullPtr.h
[+]              ./usr/include/mozjs-60/mozilla/Scoped.h
[+]              ./usr/include/mozjs-60/mozilla/Saturate.h
[+]              ./usr/include/mozjs-60/mozilla/IndexSequence.h
[+]              ./usr/include/mozjs-60/mozilla/IntegerRange.h
[+]              ./usr/include/mozjs-60/mozilla/SmallPointerArray.h
[+]              ./usr/include/mozjs-60/mozilla/ResultExtensions.h
[+]              ./usr/include/mozjs-60/mozilla/AutoProfilerLabel.h
[+]              ./usr/include/mozjs-60/mozilla/OperatorNewExtensions.h
[+]              ./usr/include/mozjs-60/mozilla/ReverseIterator.h
[+]              ./usr/include/mozjs-60/mozilla/RefPtr.h
[+]              ./usr/include/mozjs-60/mozilla/Tuple.h
[+]              ./usr/include/mozjs-60/mozilla/UniquePtrExtensions.h
[+]              ./usr/include/mozjs-60/mozilla/NotNull.h
[+]              ./usr/include/mozjs-60/mozilla/RangedPtr.h
[+]              ./usr/include/mozjs-60/mozilla/CheckedInt.h
[+]              ./usr/include/mozjs-60/mozilla/MathAlgorithms.h
[+]              ./usr/include/mozjs-60/mozilla/IntegerTypeTraits.h
[+]              ./usr/include/mozjs-60/mozilla/FloatingPoint.h
[+]              ./usr/include/mozjs-60/mozilla/JSONWriter.h
[+]              ./usr/include/mozjs-60/mozilla/Array.h
[+]              ./usr/include/mozjs-60/mozilla/Decimal.h
[+]              ./usr/include/mozjs-60/mozilla/GuardObjects.h
[+]              ./usr/include/mozjs-60/mozilla/MemoryReporting.h
[+]              ./usr/include/mozjs-60/mozilla/XorShift128PlusRNG.h
[+]              ./usr/include/mozjs-60/mozilla/RangedArray.h
[+]              ./usr/include/mozjs-60/mozilla/RefCountType.h
[+]              ./usr/include/mozjs-60/mozilla/Printf.h
[+]              ./usr/include/mozjs-60/mozilla/DebugOnly.h
[+]              ./usr/include/mozjs-60/mozilla/FastBernoulliTrial.h
[+]              ./usr/include/mozjs-60/mozilla/PlatformMutex.h
[+]              ./usr/include/mozjs-60/mozilla/PodOperations.h
[+]              ./usr/include/mozjs-60/mozilla/Range.h
[+]              ./usr/include/mozjs-60/mozilla/EnumSet.h
[+]              ./usr/include/mozjs-60/mozilla/Likely.h
[+]              ./usr/include/mozjs-60/mozilla/Compiler.h
[+]              ./usr/include/mozjs-60/mozilla/TimeStamp.h
[+]              ./usr/include/mozjs-60/mozilla/AllocPolicy.h
[+]              ./usr/include/mozjs-60/mozilla/Compression.h
[+]              ./usr/include/mozjs-60/mozilla/IntegerPrintfMacros.h
[+]              ./usr/include/mozjs-60/mozilla/TaggedAnonymousMemory.h
[+]              ./usr/include/mozjs-60/mozilla/TypeTraits.h
[+]              ./usr/include/mozjs-60/mozilla/EnumeratedArray.h
[+]              ./usr/include/mozjs-60/mozilla/ThreadSafeWeakPtr.h
[+]              ./usr/include/mozjs-60/mozilla/ThreadLocal.h
[+]              ./usr/include/mozjs-60/mozilla/Vector.h
[+]              ./usr/include/mozjs-60/mozilla/WeakPtr.h
[+]              ./usr/include/mozjs-60/mozilla/Types.h
[+]              ./usr/include/mozjs-60/mozilla/MaybeOneOf.h
[+]              ./usr/include/mozjs-60/mozilla/SegmentedVector.h
[+]              ./usr/include/mozjs-60/mozilla/Opaque.h
[+]              ./usr/include/mozjs-60/mozilla/mozalloc_abort.h
[+]              ./usr/include/mozjs-60/mozilla/mozalloc.h
[+]              ./usr/include/mozjs-60/mozilla/UniquePtr.h
[+]              ./usr/include/mozjs-60/js/GCHashTable.h
[+]              ./usr/include/mozjs-60/js/UbiNodeDominatorTree.h
[+]              ./usr/include/mozjs-60/js/Utility.h
[+]              ./usr/include/mozjs-60/js/Id.h
[+]              ./usr/include/mozjs-60/js/Stream.h
[+]              ./usr/include/mozjs-60/js/Result.h
[+]              ./usr/include/mozjs-60/js/UbiNodeCensus.h
[+]              ./usr/include/mozjs-60/js/UbiNodeShortestPaths.h
[+]              ./usr/include/mozjs-60/js/Wrapper.h
[+]              ./usr/include/mozjs-60/js/RequiredDefines.h
[+]              ./usr/include/mozjs-60/js/Conversions.h
[+]              ./usr/include/mozjs-60/js/TracingAPI.h
[+]              ./usr/include/mozjs-60/js/Realm.h
[+]              ./usr/include/mozjs-60/js/HeapAPI.h
[+]              ./usr/include/mozjs-60/js/GCVector.h
[+]              ./usr/include/mozjs-60/js/Date.h
[+]              ./usr/include/mozjs-60/js/Proxy.h
[+]              ./usr/include/mozjs-60/js/StructuredClone.h
[+]              ./usr/include/mozjs-60/js/RefCounted.h
[+]              ./usr/include/mozjs-60/js/GCVariant.h
[+]              ./usr/include/mozjs-60/js/ProfilingFrameIterator.h
[+]              ./usr/include/mozjs-60/js/GCAnnotations.h
[+]              ./usr/include/mozjs-60/js/Class.h
[+]              ./usr/include/mozjs-60/js/UbiNode.h
[+]              ./usr/include/mozjs-60/js/Value.h
[+]              ./usr/include/mozjs-60/js/ProtoKey.h
[+]              ./usr/include/mozjs-60/js/HashTable.h
[+]              ./usr/include/mozjs-60/js/Principals.h
[+]              ./usr/include/mozjs-60/js/ProfilingStack.h
[+]              ./usr/include/mozjs-60/js/WeakMapPtr.h
[+]              ./usr/include/mozjs-60/js/Initialization.h
[+]              ./usr/include/mozjs-60/js/SweepingAPI.h
[+]              ./usr/include/mozjs-60/js/MemoryMetrics.h
[+]              ./usr/include/mozjs-60/js/GCAPI.h
[+]              ./usr/include/mozjs-60/js/Printf.h
[+]              ./usr/include/mozjs-60/js/CharacterEncoding.h
[+]              ./usr/include/mozjs-60/js/Debug.h
[+]              ./usr/include/mozjs-60/js/TrackedOptimizationInfo.h
[+]              ./usr/include/mozjs-60/js/RootingAPI.h
[+]              ./usr/include/mozjs-60/js/TraceKind.h
[+]              ./usr/include/mozjs-60/js/UbiNodePostOrder.h
[+]              ./usr/include/mozjs-60/js/UbiNodeBreadthFirst.h
[+]              ./usr/include/mozjs-60/js/GCPolicyAPI.h
[+]              ./usr/include/mozjs-60/js/AllocPolicy.h
[+]              ./usr/include/mozjs-60/js/CallNonGenericMethod.h
[+]              ./usr/include/mozjs-60/js/Vector.h
[+]              ./usr/include/mozjs-60/js/SliceBudget.h
[+]              ./usr/include/mozjs-60/js/CallArgs.h
[+]              ./usr/include/mozjs-60/js/TypeDecls.h
[+]              ./usr/include/mozjs-60/js/UniquePtr.h
[+]              ./usr/lib/libmozjs-60.so
[+]              ./usr/lib/libjs_static.ajs
[+]          (That's 173 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating js-dev-60.8.0.nest
[+]      Wrapping dev-apps/js-doc#60.8.0
[!]      The package is empty -- Skipping
[+]  Done!
```