### PR TITLE
Add the sys-apps/nspr build manifest

### DIFF
--- a/sys-apps/nspr.py
+++ b/sys-apps/nspr.py
@@ -6,13 +6,24 @@ from stdlib.template import autotools
 from stdlib.manifest import manifest
 from stdlib.template.configure import configure
 from stdlib.template.make import make
+from stdlib.split.system import system
+
+
+def split_nspr():
+    packages = system()
+
+    packages['sys-apps/nspr'].drain_package(
+        packages['sys-apps/nspr-dev'],
+        'usr/lib64/*.so'
+    )
+    return packages
 
 
 @manifest(
     name='nspr',
     category='sys-apps',
     description='''
-    A platform-neutral API for system level and lic like functions.
+    A platform-neutral API for system level and libc like functions.
     ''',
     tags=['nspr', 'api', 'mozilla'],
     maintainer='dorian.trubelle@epitech.eu',
@@ -31,11 +42,10 @@ from stdlib.template.make import make
 )
 def build(build):
     packages = autotools.build(
-        build_folder='nspr',
-        configure=lambda: stdlib.cmd('../configure --prefix=/usr                \
-                            --with-mozilla                                      \
-                            --with-pthreads                                     \
-                            $([ $(uname -m) = x86_64 ] && echo --enable-64bit)'),
+        configure=lambda: configure('--with-mozilla',
+                                    '--with-pthreads',
+                                    '--enable-64bit'),
+        split=split_nspr
     )
 
     return packages

--- a/sys-apps/nspr.py
+++ b/sys-apps/nspr.py
@@ -38,9 +38,4 @@ def build(build):
                             $([ $(uname -m) = x86_64 ] && echo --enable-64bit)'),
     )
 
-    with stdlib.pushd(packages['sys-apps/nspr-dev'].wrap_cache):
-        packages['sys-apps/nspr'].drain(f'usr/lib/libplds4.so')
-        packages['sys-apps/nspr'].drain(f'usr/lib/libplc4.so')
-        packages['sys-apps/nspr'].drain(f'usr/lib/libnspr4.so')
-
     return packages

--- a/sys-apps/nspr.py
+++ b/sys-apps/nspr.py
@@ -42,9 +42,10 @@ def split_nspr():
 )
 def build(build):
     packages = autotools.build(
-        configure=lambda: configure('--with-mozilla',
-                                    '--with-pthreads',
-                                    '--enable-64bit'),
+        configure=lambda: configure(
+            '--with-mozilla',
+            '--with-pthreads',
+            '--enable-64bit'),
         split=split_nspr
     )
 

--- a/sys-apps/nspr.py
+++ b/sys-apps/nspr.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+
+import stdlib
+from stdlib.template import autotools
+from stdlib.manifest import manifest
+from stdlib.template.configure import configure
+from stdlib.template.make import make
+
+
+@manifest(
+    name='nspr',
+    category='sys-apps',
+    description='''
+    A platform-neutral API for system level and lic like functions.
+    ''',
+    tags=['nspr', 'api', 'mozilla'],
+    maintainer='dorian.trubelle@epitech.eu',
+    licenses=[stdlib.license.License.GPL, stdlib.license.License.MOZILLA],
+    upstream_url='https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR',
+    kind=stdlib.kind.Kind.EFFECTIVE,
+    versions_data=[
+        {
+            'semver': '4.24.0',
+            'fetch': [{
+                'url': 'https://archive.mozilla.org/pub/nspr/releases/v4.24/src/nspr-4.24.tar.gz',
+                'sha256': '90a59a0df6a11528749647fe18401cc7e03881e3e63c309f8c520ce06dd413d0',
+            }],
+        },
+    ],
+)
+def build(build):
+    packages = autotools.build(
+        build_folder='nspr',
+        configure=lambda: stdlib.cmd('../configure --prefix=/usr                \
+                            --with-mozilla                                      \
+                            --with-pthreads                                     \
+                            $([ $(uname -m) = x86_64 ] && echo --enable-64bit)'),
+    )
+
+    with stdlib.pushd(packages['sys-apps/nspr-dev'].wrap_cache):
+        packages['sys-apps/nspr'].drain(f'usr/lib/libplds4.so')
+        packages['sys-apps/nspr'].drain(f'usr/lib/libplc4.so')
+        packages['sys-apps/nspr'].drain(f'usr/lib/libnspr4.so')
+
+    return packages


### PR DESCRIPTION
all files belong to the packages. For the configure step, using `binary='../configure` was not working when overriding it, so I used an ugly stdlib.cmd instead
```
[+]      Wrapping sys-apps/nspr#4.24.0
[+]          name: nspr
[+]          category: sys-apps
[+]          version: 4.24.0
[+]          description: A platform-neutral API for system level and lic like functions.
[+]          tags: nspr, api, mozilla
[+]          maintainer: dorian.trubelle@epitech.eu
[+]          licenses: gpl, mozilla
[+]          upstream_url: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
[+]          kind: effective
[+]          wrap_date: 2019-12-12T00:19:48Z
[+]          dependencies:
[+]         
[+]          Files added:
[+]              ./usr/share/aclocal/nspr.m4
[+]              ./usr/lib/pkgconfig/nspr.pc
[+]              ./usr/bin/prerr.properties
[+]              ./usr/bin/compile-et.pl
[+]              ./usr/bin/nspr-config
[+]          (That's 5 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating nspr-4.24.0.nest
[+]      Wrapping sys-apps/nspr-dev#4.24.0
[+]          name: nspr-dev
[+]          category: sys-apps
[+]          version: 4.24.0
[+]          description: Headers and manuals to compile or write a software using the sys-apps/nspr package.
[+]          tags: nspr, api, mozilla
[+]          maintainer: dorian.trubelle@epitech.eu
[+]          licenses: gpl, mozilla
[+]          upstream_url: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
[+]          kind: effective
[+]          wrap_date: 2019-12-12T00:19:48Z
[+]          dependencies:
[+]              sys-libs/glibc
[+]              sys-apps/nspr#=4.24.0
[+]         
[+]          Files added:
[+]              ./usr/include/nspr/prmon.h
[+]              ./usr/include/nspr/prmwait.h
[+]              ./usr/include/nspr/prtrace.h
[+]              ./usr/include/nspr/prrwlock.h
[+]              ./usr/include/nspr/plerror.h
[+]              ./usr/include/nspr/prtime.h
[+]              ./usr/include/nspr/prcpucfg.h
[+]              ./usr/include/nspr/prinet.h
[+]              ./usr/include/nspr/plstr.h
[+]              ./usr/include/nspr/prlong.h
[+]              ./usr/include/nspr/plarena.h
[+]              ./usr/include/nspr/prenv.h
[+]              ./usr/include/nspr/prolock.h
[+]              ./usr/include/nspr/prcvar.h
[+]              ./usr/include/nspr/prvrsion.h
[+]              ./usr/include/nspr/prsystem.h
[+]              ./usr/include/nspr/prshma.h
[+]              ./usr/include/nspr/prtypes.h
[+]              ./usr/include/nspr/prnetdb.h
[+]              ./usr/include/nspr/plbase64.h
[+]              ./usr/include/nspr/prthread.h
[+]              ./usr/include/nspr/prwin16.h
[+]              ./usr/include/nspr/prio.h
[+]              ./usr/include/nspr/prproces.h
[+]              ./usr/include/nspr/prdtoa.h
[+]              ./usr/include/nspr/prcountr.h
[+]              ./usr/include/nspr/prinit.h
[+]              ./usr/include/nspr/prrng.h
[+]              ./usr/include/nspr/prprf.h
[+]              ./usr/include/nspr/nspr.h
[+]              ./usr/include/nspr/prshm.h
[+]              ./usr/include/nspr/plhash.h
[+]              ./usr/include/nspr/prmem.h
[+]              ./usr/include/nspr/prbit.h
[+]              ./usr/include/nspr/prtpool.h
[+]              ./usr/include/nspr/prpdce.h
[+]              ./usr/include/nspr/prlink.h
[+]              ./usr/include/nspr/prlock.h
[+]              ./usr/include/nspr/prerr.h
[+]              ./usr/include/nspr/prlog.h
[+]              ./usr/include/nspr/pripcsem.h
[+]              ./usr/include/nspr/plarenas.h
[+]              ./usr/include/nspr/pratom.h
[+]              ./usr/include/nspr/prcmon.h
#
[+]              ./usr/include/nspr/plgetopt.h
[+]              ./usr/include/nspr/prinrval.h
[+]              ./usr/include/nspr/prclist.h
[+]              ./usr/include/nspr/prerror.h
[+]              ./usr/include/nspr/obsolete/prsem.h
[+]              ./usr/include/nspr/obsolete/probslet.h
[+]              ./usr/include/nspr/obsolete/protypes.h
[+]              ./usr/include/nspr/obsolete/pralarm.h
[+]              ./usr/include/nspr/md/_aix64.cfg
[+]              ./usr/include/nspr/md/_win95.cfg
[+]              ./usr/include/nspr/md/_unixware.cfg
[+]              ./usr/include/nspr/md/_hpux64.cfg
[+]              ./usr/include/nspr/md/_unixware7.cfg
[+]              ./usr/include/nspr/md/_darwin.cfg
[+]              ./usr/include/nspr/md/_os2.cfg
[+]              ./usr/include/nspr/md/_qnx.cfg
[+]              ./usr/include/nspr/md/_scoos.cfg
[+]              ./usr/include/nspr/md/_hpux32.cfg
[+]              ./usr/include/nspr/md/_linux.cfg
[+]              ./usr/include/nspr/md/_aix32.cfg
[+]              ./usr/include/nspr/md/_winnt.cfg
[+]              ./usr/include/nspr/md/_bsdi.cfg
[+]              ./usr/include/nspr/md/_openbsd.cfg
[+]              ./usr/include/nspr/md/_riscos.cfg
[+]              ./usr/include/nspr/md/_freebsd.cfg
[+]              ./usr/include/nspr/md/_solaris.cfg
[+]              ./usr/include/nspr/md/_netbsd.cfg
[+]              ./usr/include/nspr/md/_nto.cfg
[+]              ./usr/include/nspr/private/prpriv.h
[+]              ./usr/include/nspr/private/pprio.h
[+]              ./usr/include/nspr/private/pprthred.h
[+]              ./usr/lib/libplds4.a
[+]              ./usr/lib/libnspr4.a
[+]              ./usr/lib/libplc4.a
[+]              ./usr/lib/libplds4.so
[+]              ./usr/lib/libplc4.so
[+]              ./usr/lib/libnspr4.so
[+]          (That's 81 files.)
[+]          Creating data.tar.gz
[+]          Creating manifest.toml
[+]          Creating nspr-dev-4.24.0.nest
[+]      Wrapping sys-apps/nspr-doc#4.24.0
[!]      The package is empty -- Skipping
[+]  Done!
```